### PR TITLE
With -Dquickly, build wildfly-preview feature pack; just skip the tim…

### DIFF
--- a/preview/pom.xml
+++ b/preview/pom.xml
@@ -31,6 +31,13 @@
         <preview.dist.product.release.version>${full.dist.product.release.version}</preview.dist.product.release.version>
     </properties>
 
+    <modules>
+        <module>channel</module>
+        <module>feature-pack</module>
+        <module>galleon-local</module>
+        <module>product-conf</module>
+    </modules>
+
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -98,11 +105,7 @@
             </activation>
             <modules>
                 <module>build</module>
-                <module>channel</module>
                 <module>dist</module>
-                <module>feature-pack</module>
-                <module>galleon-local</module>
-                <module>product-conf</module>
             </modules>
         </profile>
     </profiles>


### PR DESCRIPTION
…e consuming build and dist modules

@TomasHofman I think this will fix the problem with https://github.com/wildfly/wildfly/pull/18723.

Building the wildfly-preview feature pack takes very little time, so it's ok to do it with -Dquickly.  It's the build and dist modules that are time consuming.

If this seems ok, please squash it in so the history doesn't have a partly broken commit.